### PR TITLE
Removing *alpha quality* from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Archimedes contains useful geometry functions for your Cocoa or Cocoa Touch application.
 
-This framework is very much a work in progress at the moment, and should be considered **alpha quality**. Breaking changes may happen often during this time.
-
 ## Getting Started
 
 To start building the framework, clone this repository and then run `script/bootstrap`.


### PR DESCRIPTION
… so we can tag this 1.0.

I mostly wanted to tag HEAD to update the CocoaPod spec.

That being said, if there's anything that prevents the current state of affairs from being "a proper 1.0" , let me know. 
Tagging it 0.5 would also work, I don't feel too strongly about this.

Getting in #21 would be nice, too.
